### PR TITLE
Add daily percent-change chart to precious metals notebook

### DIFF
--- a/docs/Finance/Precious_Metals_Spot_Prices_Comparison.ipynb
+++ b/docs/Finance/Precious_Metals_Spot_Prices_Comparison.ipynb
@@ -1,0 +1,206 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Precious Metal Spot Price Comparison (5 Years)\n",
+        "\n",
+        "This notebook compares precious metal spot prices over the last five years and builds a simple forecast using interactive charts.\n",
+        "\n",
+        "## Where to get spot price data\n",
+        "\n",
+        "Common sources for spot price data include:\n",
+        "\n",
+        "- **LBMA (London Bullion Market Association)**: Official daily gold and silver price benchmarks. Useful for authoritative spot pricing.\n",
+        "- **Metals-API**: Paid/free tiers with JSON API access for multiple metals (gold, silver, platinum, palladium).\n",
+        "- **Alpha Vantage**: Free tier provides precious metals data with API keys and rate limits.\n",
+        "- **Quandl/Nasdaq Data Link**: Offers LBMA and other datasets (free and paid).\n",
+        "- **Yahoo Finance**: Convenient access for analysis (e.g., `XAUUSD=X`, `XAGUSD=X`, `XPTUSD=X`, `XPDUSD=X`). While not an official benchmark, it's easy to use for exploratory analysis.\n",
+        "\n",
+        "This notebook uses **Yahoo Finance** spot proxies for convenience.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# If needed, install dependencies\n",
+        "# !pip install -q yfinance pandas plotly statsmodels\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import pandas as pd\n",
+        "import yfinance as yf\n",
+        "import plotly.express as px\n",
+        "import plotly.graph_objects as go\n",
+        "from statsmodels.tsa.holtwinters import ExponentialSmoothing\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "tickers = {\n",
+        "    \"Gold (XAUUSD)\": \"XAUUSD=X\",\n",
+        "    \"Silver (XAGUSD)\": \"XAGUSD=X\",\n",
+        "    \"Platinum (XPTUSD)\": \"XPTUSD=X\",\n",
+        "    \"Palladium (XPDUSD)\": \"XPDUSD=X\",\n",
+        "}\n",
+        "\n",
+        "price_frames = []\n",
+        "for label, ticker in tickers.items():\n",
+        "    data = yf.download(ticker, period=\"5y\", interval=\"1d\", auto_adjust=True, progress=False)\n",
+        "    series = data[\"Close\"].rename(label)\n",
+        "    price_frames.append(series)\n",
+        "\n",
+        "prices = pd.concat(price_frames, axis=1).dropna(how=\"all\")\n",
+        "prices.tail()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = px.line(\n",
+        "    prices,\n",
+        "    x=prices.index,\n",
+        "    y=prices.columns,\n",
+        "    title=\"Spot Price Comparison (Last 5 Years)\",\n",
+        "    labels={\"value\": \"USD per troy ounce\", \"index\": \"Date\"},\n",
+        ")\n",
+        "fig.update_layout(legend_title_text=\"Metal\")\n",
+        "fig.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "normalized = prices / prices.iloc[0] * 100\n",
+        "\n",
+        "fig = px.line(\n",
+        "    normalized,\n",
+        "    x=normalized.index,\n",
+        "    y=normalized.columns,\n",
+        "    title=\"Normalized Performance (100 = Start of Period)\",\n",
+        "    labels={\"value\": \"Index (100 = start)\", \"index\": \"Date\"},\n",
+        ")\n",
+        "fig.update_layout(legend_title_text=\"Metal\")\n",
+        "fig.show()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "pct_change = prices.pct_change().dropna() * 100\n",
+        "\n",
+        "fig = px.line(\n",
+        "    pct_change,\n",
+        "    x=pct_change.index,\n",
+        "    y=pct_change.columns,\n",
+        "    title=\"Daily Percent Change (Last 5 Years)\",\n",
+        "    labels={\"value\": \"Percent change (%)\", \"index\": \"Date\"},\n",
+        ")\n",
+        "fig.update_layout(legend_title_text=\"Metal\")\n",
+        "fig.show()\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Simple Forecast (12 Months)\n",
+        "\n",
+        "We use a basic Holt-Winters exponential smoothing model on monthly averages to produce a simple, transparent forecast.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "monthly = prices.resample(\"M\").mean().dropna()\n",
+        "forecast_horizon = 12\n",
+        "\n",
+        "forecast_frames = []\n",
+        "for metal in monthly.columns:\n",
+        "    model = ExponentialSmoothing(\n",
+        "        monthly[metal],\n",
+        "        trend=\"add\",\n",
+        "        seasonal=None,\n",
+        "        initialization_method=\"estimated\",\n",
+        "    ).fit()\n",
+        "    forecast = model.forecast(forecast_horizon)\n",
+        "    forecast.name = metal\n",
+        "    forecast_frames.append(forecast)\n",
+        "\n",
+        "forecast_df = pd.concat(forecast_frames, axis=1)\n",
+        "forecast_df.tail()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "fig = go.Figure()\n",
+        "for metal in monthly.columns:\n",
+        "    fig.add_trace(\n",
+        "        go.Scatter(\n",
+        "            x=monthly.index,\n",
+        "            y=monthly[metal],\n",
+        "            name=f\"{metal} (history)\",\n",
+        "        )\n",
+        "    )\n",
+        "    fig.add_trace(\n",
+        "        go.Scatter(\n",
+        "            x=forecast_df.index,\n",
+        "            y=forecast_df[metal],\n",
+        "            name=f\"{metal} (forecast)\",\n",
+        "            line=dict(dash=\"dash\"),\n",
+        "        )\n",
+        "    )\n",
+        "\n",
+        "fig.update_layout(\n",
+        "    title=\"12-Month Forecast (Holt-Winters, Monthly Avg)\",\n",
+        "    xaxis_title=\"Date\",\n",
+        "    yaxis_title=\"USD per troy ounce\",\n",
+        "    legend_title_text=\"Series\",\n",
+        ")\n",
+        "fig.show()\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}


### PR DESCRIPTION
### Motivation
- Provide a daily percent-change view so short-term momentum and relative upside across metals can be compared alongside the existing price and normalized charts.

### Description
- Update `docs/Finance/Precious_Metals_Spot_Prices_Comparison.ipynb` to insert a code cell that computes `pct_change = prices.pct_change().dropna() * 100` and renders an interactive Plotly Express line chart titled "Daily Percent Change (Last 5 Years)".
- The new chart is placed after the existing "Normalized Performance" cell and uses `px.line` with `labels` and `fig.update_layout(legend_title_text="Metal")` to match the notebook's style.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969505ea2788325a938f006c73f4fbc)